### PR TITLE
Add covariance #4

### DIFF
--- a/include/cugo_ros_control/cugo_ros_control.hpp
+++ b/include/cugo_ros_control/cugo_ros_control.hpp
@@ -71,6 +71,9 @@ class CugoController {
     float abnormal_translation_acc_limit = 10.0;
     float abnormal_angular_acc_limit = 10.0 * M_PI / 4;
 
+    XmlRpc::XmlRpcValue pose_cov_arry;
+    XmlRpc::XmlRpcValue twist_cov_arry;
+
     int stop_motor_time = 500; //NavigationやコントローラからSubscriberできなかったときにモータを>止めるまでの時間(ms)
 
     float vector_v       = 0.0;

--- a/launch/bringup/cugo_ros_control.launch
+++ b/launch/bringup/cugo_ros_control.launch
@@ -21,6 +21,12 @@
         <param name="odom_child_frame_id" value="base_footprint" />
         <param name="abnormal_translation_acc_limit" value="10.0" />
         <param name="abnormal_angular_acc_limit" value="7.85" />
+        <rosparam>
+          pose_covariance_diagonal: [0.001, 0.001, 1000000.0, 1000000.0, 1000000.0, 1000.0]
+        </rosparam>
+        <rosparam>
+          twist_covariance_diagonal: [0.001, 0.001, 1000000.0, 1000000.0, 1000000.0, 1000.0]
+        </rosparam>
 	<remap from="/cugo_ros_control/odom" to="/odom" />
     </node>
 </launch>

--- a/src/cugo_ros_control.cpp
+++ b/src/cugo_ros_control.cpp
@@ -32,6 +32,24 @@ CugoController::CugoController(ros::NodeHandle nh) : loop_rate(10)
   nh.param("abnormal_translation_acc_limit", abnormal_translation_acc_limit, (float)10.0);
   nh.param("abnormal_angular_acc_limit", abnormal_angular_acc_limit, (float)(10.0*M_PI/4));
 
+  // get and check params for covariances
+  nh.getParam("pose_covariance_diagonal", pose_cov_arry);
+  ROS_ASSERT(pose_cov_arry.getType() == XmlRpc::XmlRpcValue::TypeArray);
+  ROS_ASSERT(pose_cov_arry.size() == 6);
+  for(int i = 0; i < pose_cov_arry.size(); ++i)
+  {
+    ROS_ASSERT(pose_cov_arry[i].getType() == XmlRpc::XmlRpcValue::TypeDouble);
+  }
+
+  nh.getParam("twist_covariance_diagonal", twist_cov_arry);
+  ROS_ASSERT(twist_cov_arry.getType() == XmlRpc::XmlRpcValue::TypeArray);
+  ROS_ASSERT(twist_cov_arry.size() == 6);
+  for(int i = 0; i < twist_cov_arry.size(); ++i)
+  {
+    ROS_ASSERT(twist_cov_arry[i].getType() == XmlRpc::XmlRpcValue::TypeDouble);
+  }
+
+
   view_parameters();
   //view_init();
 }

--- a/src/cugo_ros_control.cpp
+++ b/src/cugo_ros_control.cpp
@@ -295,12 +295,26 @@ void CugoController::publish()
   odom.pose.pose.position.y = odom_y;
   odom.pose.pose.position.z = 0.0;
   odom.pose.pose.orientation = odom_quat;
+  odom.pose.covariance = {
+    static_cast<double>(pose_cov_arry[0]), 0., 0., 0., 0., 0.,
+    0., static_cast<double>(pose_cov_arry[1]), 0., 0., 0., 0.,
+    0., 0., static_cast<double>(pose_cov_arry[2]), 0., 0., 0.,
+    0., 0., 0., static_cast<double>(pose_cov_arry[3]), 0., 0.,
+    0., 0., 0., 0., static_cast<double>(pose_cov_arry[4]), 0.,
+    0., 0., 0., 0., 0., static_cast<double>(pose_cov_arry[5]) };
 
   // set the velocity
   odom.child_frame_id = odom_child_frame_id;
   odom.twist.twist.linear.x = odom_twist_x;
   odom.twist.twist.linear.y = odom_twist_y;
   odom.twist.twist.angular.z = odom_twist_yaw;
+  odom.twist.covariance = {
+    static_cast<double>(twist_cov_arry[0]), 0., 0., 0., 0., 0.,
+    0., static_cast<double>(twist_cov_arry[1]), 0., 0., 0., 0.,
+    0., 0., static_cast<double>(twist_cov_arry[2]), 0., 0., 0.,
+    0., 0., 0., static_cast<double>(twist_cov_arry[3]), 0., 0.,
+    0., 0., 0., 0., static_cast<double>(twist_cov_arry[4]), 0.,
+    0., 0., 0., 0., 0., static_cast<double>(twist_cov_arry[5]) };
 
   view_odom();
   odom_pub.publish(odom);


### PR DESCRIPTION
issue #4 の解決

- parameterにposeとtwistでのcovarianceを設定できるようにした
  - pose_covariance_diagonal
  - twist_covariance_diagonal
- /odomトピックがposeとtwistでのcovarianceを持った状態でpublishするようにした