### PR TITLE
変更：checksum失敗時、/odomをpublishしないように変更

### DIFF
--- a/include/cugo_ros2_control/cugo_ros2_control.hpp
+++ b/include/cugo_ros2_control/cugo_ros2_control.hpp
@@ -83,6 +83,7 @@ class CugoController : public rclcpp::Node
     int source_port = 8888;
     std::string odom_frame_id;
     std::string odom_child_frame_id;
+    bool recv_success = false;
 
     float abnormal_translation_acc_limit = 10.0;
     float abnormal_angular_acc_limit = 10.0 * M_PI / 4;


### PR DESCRIPTION
100分耐久で通信失敗後に０が代入されることが一度もないことを確認した。